### PR TITLE
[FIX] Fix wrong URL in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,5 +2,5 @@
 
 mkdir -p .devcontainer
 
-curl -fsSL https://raw.githubusercontent.com/itislu/42-Docker-DevEnv/main/.devcontainer/Dockerfile -o .devcontainer/Dockerfile
-curl -fsSL https://raw.githubusercontent.com/itislu/42-Docker-DevEnv/main/.devcontainer/devcontainer.json -o .devcontainer/devcontainer.json
+curl -fsSL https://raw.githubusercontent.com/LeaYeh/42-Docker-DevEnv/main/.devcontainer/Dockerfile -o .devcontainer/Dockerfile
+curl -fsSL https://raw.githubusercontent.com/LeaYeh/42-Docker-DevEnv/main/.devcontainer/devcontainer.json -o .devcontainer/devcontainer.json


### PR DESCRIPTION
I deleted my fork a few days ago, so the install script didn't work since then.