### PR TITLE
[FEAT] Add same versions of compilers, valgrind and readline

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -61,25 +61,25 @@ RUN wget https://sourceware.org/pub/valgrind/valgrind-3.18.1.tar.bz2 \
     && rm -rf valgrind-3.18.1*
 
 # Make 4.3
-RUN wget http://ftp.gnu.org/gnu/make/make-4.3.tar.gz && \
-	tar -xvzf make-4.3.tar.gz && \
-	cd make-4.3 && \
-	./configure && \
-	make && \
-	sudo make install && \
-    cd .. && \
-    rm -rf make-4.3*
+RUN wget http://ftp.gnu.org/gnu/make/make-4.3.tar.gz \
+    && tar -xvzf make-4.3.tar.gz \
+    && cd make-4.3 \
+    && ./configure \
+    && make \
+    && sudo make install \
+    && cd .. \
+    && rm -rf make-4.3*
 
 # Readline 8.1
-RUN wget https://ftp.gnu.org/gnu/readline/readline-8.1.tar.gz && \
-    tar -xzvf readline-8.1.tar.gz && \
-    cd readline-8.1 && \
-    ./configure --enable-shared && \
-    make && \
-    sudo make install && \
-    sudo ldconfig && \
-    cd .. && \
-    rm -rf readline-8.1*
+RUN wget https://ftp.gnu.org/gnu/readline/readline-8.1.tar.gz \
+    && tar -xzvf readline-8.1.tar.gz \
+    && cd readline-8.1 \
+    && ./configure --enable-shared \
+    && make \
+    && sudo make install \
+    && sudo ldconfig \
+    && cd .. \
+    && rm -rf readline-8.1*
 
 # Create a virtual environment and activate it
 RUN python3 -m venv /opt/venv
@@ -91,12 +91,12 @@ RUN python3 -m pip install --upgrade pip setuptools
 RUN python3 -m pip install norminette
 
 # Install MLX library
-RUN cd $HOME && \
-    git clone https://github.com/42Paris/minilibx-linux.git && \
-    cd minilibx-linux && \
-    make && \
-    sudo cp mlx.h /usr/local/include && \
-    sudo cp libmlx.a /usr/local/lib
+RUN cd $HOME \
+    && git clone https://github.com/42Paris/minilibx-linux.git \
+    && cd minilibx-linux \
+    && make \
+    && sudo cp mlx.h /usr/local/include \
+    && sudo cp libmlx.a /usr/local/lib
 
 # Install francinette
 RUN bash -c "$(curl -fsSL https://raw.github.com/xicodomingues/francinette/master/bin/install.sh)"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -100,12 +100,3 @@ RUN cd $HOME && \
 
 # Install francinette
 RUN bash -c "$(curl -fsSL https://raw.github.com/xicodomingues/francinette/master/bin/install.sh)"
-
-# Install oh-my-zsh
-RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" || true
-RUN echo "source $HOME/.oh-my-zsh/oh-my-zsh.sh" >> $HOME/.zshrc
-
-# Set the working directory in the container to /app
-WORKDIR /app
-
-CMD ["/bin/zsh"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -105,7 +105,7 @@ RUN bash -c "$(curl -fsSL https://raw.github.com/xicodomingues/francinette/maste
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" || true
 RUN echo "source $HOME/.oh-my-zsh/oh-my-zsh.sh" >> $HOME/.zshrc
 
-# Set the working directory in the container to /app
-WORKDIR /app
+# Set the working directory in the container
+WORKDIR /workspace
 
 CMD ["/bin/zsh"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,14 @@
-# Start from the latest Ubuntu version
-FROM ubuntu:latest
+# Start from Ubuntu 22.04 (Jammy Jellyfish)
+FROM ubuntu:22.04
+
+# Add LLVM and GCC repositories
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get -y install \
+    wget \
+    gnupg \
+    software-properties-common \
+    && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main" \
+    && add-apt-repository ppa:ubuntu-toolchain-r/test
 
 # Update the system and install utils
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -10,6 +19,14 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
     binutils \
     clang \
+    clang-14 \
+    clang-12 \
+    lldb-12 \
+    gdb \
+    gcc-11=11.4.0-1ubuntu1~22.04 \
+    g++-11=11.4.0-1ubuntu1~22.04 \
+    gcc-10=10.5.0-1ubuntu1~22.04 \
+    g++-10=10.5.0-1ubuntu1~22.04 \
     zsh \
     git \
     wget \
@@ -19,15 +36,50 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libreadline8 \
     xorg libxext-dev zlib1g-dev libbsd-dev \
     libcmocka-dev \
-    pkg-config
+    pkg-config \
+    cppcheck \
+    clangd \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# Download and install the latest version of make
+# Set up compiler aliases
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 100 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 100 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-12 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-12 100
+
+# Valgrind 3.18.1
+RUN wget https://sourceware.org/pub/valgrind/valgrind-3.18.1.tar.bz2 \
+    && tar -xjf valgrind-3.18.1.tar.bz2 \
+    && cd valgrind-3.18.1 \
+    && ./configure \
+    && make \
+    && make install \
+    && sudo ldconfig \
+    && cd .. \
+    && rm -rf valgrind-3.18.1*
+
+# Make 4.3
 RUN wget http://ftp.gnu.org/gnu/make/make-4.3.tar.gz && \
-    tar -xvzf make-4.3.tar.gz && \
-    cd make-4.3 && \
-    ./configure && \
+	tar -xvzf make-4.3.tar.gz && \
+	cd make-4.3 && \
+	./configure && \
+	make && \
+	sudo make install && \
+    cd .. && \
+    rm -rf make-4.3*
+
+# Readline 8.1
+RUN wget https://ftp.gnu.org/gnu/readline/readline-8.1.tar.gz && \
+    tar -xzvf readline-8.1.tar.gz && \
+    cd readline-8.1 && \
+    ./configure --enable-shared && \
     make && \
-    sudo make install
+    sudo make install && \
+    sudo ldconfig && \
+    cd .. && \
+    rm -rf readline-8.1*
 
 # Create a virtual environment and activate it
 RUN python3 -m venv /opt/venv

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -100,3 +100,12 @@ RUN cd $HOME \
 
 # Install francinette
 RUN bash -c "$(curl -fsSL https://raw.github.com/xicodomingues/francinette/master/bin/install.sh)"
+
+# Install oh-my-zsh
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" || true
+RUN echo "source $HOME/.oh-my-zsh/oh-my-zsh.sh" >> $HOME/.zshrc
+
+# Set the working directory in the container to /app
+WORKDIR /app
+
+CMD ["/bin/zsh"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -106,6 +106,6 @@ RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master
 RUN echo "source $HOME/.oh-my-zsh/oh-my-zsh.sh" >> $HOME/.zshrc
 
 # Set the working directory in the container
-WORKDIR /workspace
+WORKDIR /app
 
 CMD ["/bin/zsh"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,11 +18,23 @@
 			},
 			"extensions": [
 				"ms-vscode.cpptools-extension-pack",
+				"llvm-vs-code-extensions.vscode-clangd",
+				"vadimcn.vscode-lldb",
 				"ms-python.python",
 				"eamodio.gitlens",
 				"github.copilot",
+				"jeff-hykin.better-cpp-syntax",
+				"solomonkinard.workspace-include-what-you-use",
+				"bbenoist.togglehs",
+				"ms-vscode.makefile-tools",
+				"timonwong.shellcheck",
+				"esbenp.prettier-vscode",
 				"kube.42header",
-				"DoKca.42-ft-count-line"
+				"DoKca.42-ft-count-line",
+				"ms-vsliveshare.vsliveshare",
+				"dqisme.sync-scroll",
+				"uctakeoff.vscode-counter",
+				"tomoki1207.pdf"
 			]
 		}
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,45 +1,43 @@
 {
-	"name": "42-Docker-DevEnv",
-	"build": {
-		"dockerfile": "Dockerfile"
-	},
-	"runArgs": [
-		"--privileged"
-	],
-	"customizations": {
-		"vscode": {
-			"settings": {
-				"terminal.integrated.shell.linux": "/bin/zsh"
-			},
-			"extensions": [
-				"ms-vscode.cpptools-extension-pack",
-				"llvm-vs-code-extensions.vscode-clangd",
-				"vadimcn.vscode-lldb",
-				"ms-python.python",
-				"eamodio.gitlens",
-				"github.copilot",
-				"jeff-hykin.better-cpp-syntax",
-				"solomonkinard.workspace-include-what-you-use",
-				"bbenoist.togglehs",
-				"ms-vscode.makefile-tools",
-				"timonwong.shellcheck",
-				"esbenp.prettier-vscode",
-				"kube.42header",
-				"DoKca.42-ft-count-line",
-				"ms-vsliveshare.vsliveshare",
-				"dqisme.sync-scroll",
-				"uctakeoff.vscode-counter",
-				"tomoki1207.pdf"
-			]
-		}
-	},
-	"initializeCommand": "mkdir -p ${env:HOME}/.ssh && touch ${env:HOME}/.gitconfig ${env:HOME}/.zshrc",
-	"mounts": [
-		"source=${env:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached",
-		"source=${env:HOME}/.gitconfig,target=/root/.gitconfig,type=bind,consistency=cached",
-		"source=${env:HOME}/.zshrc,target=/root/.zshrc,type=bind,consistency=cached"
-	],
-	"workspaceFolder": "/workspace",
-	"workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
-	"remoteUser": "root"
+    "name": "42-Docker-DevEnv",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "runArgs": ["--privileged"],
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "terminal.integrated.shell.linux": "/bin/zsh"
+            },
+            "extensions": [
+                "ms-vscode.cpptools-extension-pack",
+                "llvm-vs-code-extensions.vscode-clangd",
+                "vadimcn.vscode-lldb",
+                "ms-python.python",
+                "eamodio.gitlens",
+                "github.copilot",
+                "jeff-hykin.better-cpp-syntax",
+                "solomonkinard.workspace-include-what-you-use",
+                "bbenoist.togglehs",
+                "ms-vscode.makefile-tools",
+                "timonwong.shellcheck",
+                "esbenp.prettier-vscode",
+                "kube.42header",
+                "DoKca.42-ft-count-line",
+                "ms-vsliveshare.vsliveshare",
+                "dqisme.sync-scroll",
+                "uctakeoff.vscode-counter",
+                "tomoki1207.pdf"
+            ]
+        }
+    },
+    "initializeCommand": "mkdir -p ${env:HOME}/.ssh && touch ${env:HOME}/.gitconfig ${env:HOME}/.zshrc",
+    "mounts": [
+        "source=${env:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached",
+        "source=${env:HOME}/.gitconfig,target=/root/.gitconfig,type=bind,consistency=cached",
+        "source=${env:HOME}/.zshrc,target=/root/.zshrc,type=bind,consistency=cached"
+    ],
+    "workspaceFolder": "/app",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind",
+    "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,23 +11,21 @@
             },
             "extensions": [
                 "ms-vscode.cpptools-extension-pack",
-                "llvm-vs-code-extensions.vscode-clangd",
-                "vadimcn.vscode-lldb",
+                // "llvm-vs-code-extensions.vscode-clangd", // Alternative language server for C/C++
                 "ms-python.python",
-                "eamodio.gitlens",
                 "github.copilot",
-                "jeff-hykin.better-cpp-syntax",
-                "solomonkinard.workspace-include-what-you-use",
-                "bbenoist.togglehs",
-                "ms-vscode.makefile-tools",
-                "timonwong.shellcheck",
-                "esbenp.prettier-vscode",
-                "kube.42header",
-                "DoKca.42-ft-count-line",
-                "ms-vsliveshare.vsliveshare",
-                "dqisme.sync-scroll",
-                "uctakeoff.vscode-counter",
-                "tomoki1207.pdf"
+                "vadimcn.vscode-lldb", // Improved debugger features
+                "eamodio.gitlens", // Powerful git UI and visualizations
+                "bbenoist.togglehs", // F4 to jump between header and source files
+                "ms-vscode.makefile-tools", // IntelliSense for Makefile
+                "timonwong.shellcheck", // Linter for Shell scripts
+                "esbenp.prettier-vscode", // Code formatter for Markdown, YAML and more
+                "kube.42header", // Ctrl + Alt + H to insert 42 Header
+                "DoKca.42-ft-count-line", // Display function line count
+                "ms-vsliveshare.vsliveshare", // Real-time collaboration
+                "dqisme.sync-scroll", // Scroll multiple editors simultaneously
+                "uctakeoff.vscode-counter", // Count lines of code
+                "tomoki1207.pdf" // Display PDF files in VS Code
             ]
         }
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,8 +36,5 @@
         "source=${env:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached",
         "source=${env:HOME}/.gitconfig,target=/root/.gitconfig,type=bind,consistency=cached",
         "source=${env:HOME}/.zshrc,target=/root/.zshrc,type=bind,consistency=cached"
-    ],
-    "workspaceFolder": "/app",
-    "workspaceMount": "source=${localWorkspaceFolder},target=/app,type=bind",
-    "remoteUser": "root"
+    ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,11 +3,6 @@
 	"build": {
 		"dockerfile": "Dockerfile"
 	},
-	"features": {
-		"ghcr.io/devcontainers/features/common-utils": {
-			"configureZshAsDefaultShell": true
-		}
-    },
 	"runArgs": [
 		"--privileged"
 	],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,11 @@
 	"build": {
 		"dockerfile": "Dockerfile"
 	},
+	"features": {
+		"ghcr.io/devcontainers/features/common-utils": {
+			"configureZshAsDefaultShell": true
+		}
+    },
 	"runArgs": [
 		"--privileged"
 	],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
 			]
 		}
 	},
-	"initializeCommand": "touch ${env:HOME}/.ssh ${env:HOME}/.gitconfig ${env:HOME}/.zshrc",
+	"initializeCommand": "mkdir -p ${env:HOME}/.ssh && touch ${env:HOME}/.gitconfig ${env:HOME}/.zshrc",
 	"mounts": [
 		"source=${env:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached",
 		"source=${env:HOME}/.gitconfig,target=/root/.gitconfig,type=bind,consistency=cached",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
-# Start from the latest Ubuntu version
-FROM ubuntu:latest
+# Start from Ubuntu 22.04 (Jammy Jellyfish)
+FROM ubuntu:22.04
+
+# Add LLVM and GCC repositories
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get -y install \
+    wget \
+    gnupg \
+    software-properties-common \
+    && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main" \
+    && add-apt-repository ppa:ubuntu-toolchain-r/test
 
 # Update the system and install utils
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -10,6 +19,14 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
     binutils \
     clang \
+    clang-14 \
+    clang-12 \
+    lldb-12 \
+    gdb \
+    gcc-11=11.4.0-1ubuntu1~22.04 \
+    g++-11=11.4.0-1ubuntu1~22.04 \
+    gcc-10=10.5.0-1ubuntu1~22.04 \
+    g++-10=10.5.0-1ubuntu1~22.04 \
     zsh \
     git \
     wget \
@@ -19,15 +36,50 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libreadline8 \
     xorg libxext-dev zlib1g-dev libbsd-dev \
     libcmocka-dev \
-    pkg-config
+    pkg-config \
+    cppcheck \
+    clangd \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# Download and install the latest version of make
-RUN wget http://ftp.gnu.org/gnu/make/make-4.3.tar.gz && \
-    tar -xvzf make-4.3.tar.gz && \
-    cd make-4.3 && \
-    ./configure && \
-    make && \
-    sudo make install
+# Set up compiler aliases
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 100 \
+    && update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 100 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/clang-12 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-12 100
+
+# Valgrind 3.18.1
+RUN wget https://sourceware.org/pub/valgrind/valgrind-3.18.1.tar.bz2 \
+    && tar -xjf valgrind-3.18.1.tar.bz2 \
+    && cd valgrind-3.18.1 \
+    && ./configure \
+    && make \
+    && make install \
+    && sudo ldconfig \
+    && cd .. \
+    && rm -rf valgrind-3.18.1*
+
+# Make 4.3
+RUN wget http://ftp.gnu.org/gnu/make/make-4.3.tar.gz \
+    && tar -xvzf make-4.3.tar.gz \
+    && cd make-4.3 \
+    && ./configure \
+    && make \
+    && sudo make install \
+    && cd .. \
+    && rm -rf make-4.3*
+
+# Readline 8.1
+RUN wget https://ftp.gnu.org/gnu/readline/readline-8.1.tar.gz \
+    && tar -xzvf readline-8.1.tar.gz \
+    && cd readline-8.1 \
+    && ./configure --enable-shared \
+    && make \
+    && sudo make install \
+    && sudo ldconfig \
+    && cd .. \
+    && rm -rf readline-8.1*
 
 # Create a virtual environment and activate it
 RUN python3 -m venv /opt/venv
@@ -39,12 +91,12 @@ RUN python3 -m pip install --upgrade pip setuptools
 RUN python3 -m pip install norminette
 
 # Install MLX library
-RUN cd $HOME && \
-    git clone https://github.com/42Paris/minilibx-linux.git && \
-    cd minilibx-linux && \
-    make && \
-    sudo cp mlx.h /usr/local/include && \
-    sudo cp libmlx.a /usr/local/lib
+RUN cd $HOME \
+    && git clone https://github.com/42Paris/minilibx-linux.git \
+    && cd minilibx-linux \
+    && make \
+    && sudo cp mlx.h /usr/local/include \
+    && sudo cp libmlx.a /usr/local/lib
 
 # Install francinette
 RUN bash -c "$(curl -fsSL https://raw.github.com/xicodomingues/francinette/master/bin/install.sh)"
@@ -53,7 +105,7 @@ RUN bash -c "$(curl -fsSL https://raw.github.com/xicodomingues/francinette/maste
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" || true
 RUN echo "source $HOME/.oh-my-zsh/oh-my-zsh.sh" >> $HOME/.zshrc
 
-# Set the working directory in the container to /app
-WORKDIR /app
+# Set the working directory in the container
+WORKDIR /workspace
 
 CMD ["/bin/zsh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,6 @@ RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master
 RUN echo "source $HOME/.oh-my-zsh/oh-my-zsh.sh" >> $HOME/.zshrc
 
 # Set the working directory in the container
-WORKDIR /workspace
+WORKDIR /app
 
 CMD ["/bin/zsh"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This repository is created for 42Campus students to have the same environment as in campus PCs. The goal is to make remote work as seamless and productive as possible.
 
+The configuration is based on 42 Vienna's installed versions and tools.
+
 ## Prerequisites
 
 Before you begin, ensure you have met the following requirements:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   run-container:
     container_name: 42-Docker-DevEnv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,12 @@ services:
       args:
         USER: ${USER}
     volumes:
-      - .:/app
+      - .:/workspace
+      - ${HOME}/.ssh:/root/.ssh:cached
+      - ${HOME}/.gitconfig:/root/.gitconfig:cached
+      - ${HOME}/.zshrc:/root/.zshrc:cached
     environment:
       - USER=${USER}
     user: root
-    command: ["sh", "-c", "sudo chmod -R 755 /app && sleep infinity"]
+    command: ["sh", "-c", "sudo chmod -R 755 /workspace && sleep infinity"]
+    privileged: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   run-container:
+    container_name: 42-Docker-DevEnv
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,12 @@ services:
       args:
         USER: ${USER}
     volumes:
-      - .:/workspace
+      - .:/app
       - ${HOME}/.ssh:/root/.ssh:cached
       - ${HOME}/.gitconfig:/root/.gitconfig:cached
       - ${HOME}/.zshrc:/root/.zshrc:cached
     environment:
       - USER=${USER}
     user: root
-    command: ["sh", "-c", "sudo chmod -R 755 /workspace && sleep infinity"]
+    command: ["sh", "-c", "sudo chmod -R 755 /app && sleep infinity"]
     privileged: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,6 @@ services:
       - ${HOME}/.zshrc:/root/.zshrc:cached
     environment:
       - USER=${USER}
-    user: root
-    command: ["sh", "-c", "sudo chmod -R 755 /app && sleep infinity"]
-    privileged: true
+    working_dir: /app
+    stdin_open: true
+    tty: true

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
 
+# Download latest Dockerfile and docker-compose.yml
 curl -fsSL https://raw.githubusercontent.com/LeaYeh/42-Docker-DevEnv/main/Dockerfile -o Dockerfile
 curl -fsSL https://raw.githubusercontent.com/LeaYeh/42-Docker-DevEnv/main/docker-compose.yml -o docker-compose.yml
 
-docker build --build-arg USER=$USER -t develop-env .
-# docker build --progress=plain --build-arg USER=$USER -t develop-env .
-# docker exec -it -u leayeh <container_id> /bin/bash
+# Set environment variable for current user
 echo "USER=$(whoami)" > .env
+
+# Create required directories and files
+mkdir -p "${HOME}/.ssh"
+touch "${HOME}/.gitconfig" "${HOME}/.zshrc"
+
+# Build and run the container
 docker-compose up --build -d run-container
+
+# Print helpful message
+echo "Container is running! To attach to it, use:"
+echo "docker exec -it \$(docker-compose ps -q run-container) /bin/zsh"
+echo
+echo "Check the README how to attach to the container with VS Code."


### PR DESCRIPTION
Also:
- Use same Ubuntu version as on campus for base image.
- Add more VS Code extensions.
- Let devcontainer start in `/workspaces/<project_directory>`.
- Update the docker-compose to behave same as devcontainer, except VS Code settings, extensions and current directory.
- Replace infinite sleep with better solution in docker-compose.
- Update the run script for pure Docker container with short help message and only use `docker-compose`, not also `docker build`.
- Add note in README that "The configuration is based on 42 Vienna's installed versions and tools."